### PR TITLE
chore: Enhance the README with information about Cluster Profile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,39 @@
-# ClusterInventory API
+# Cluster Inventory API
 
-The `ClusterInventory API` provides a reliable, consistent, and automated approach for any multi-cluster application (framework, toolset) to discover available clusters and take actions accordingly, in a way similar to service discovery works in a microservice architecture. Through the inventory, the application can query for a list of clusters to access, or watch for an ever-flowing stream of cluster lifecycle events which the application can act upon timely, such as auto-scaling, upgrades, failures, and connectivity issues.
-This repo will hold design documents and implementation of the cluster inventory API as described in [KEP 4322](https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/4322-cluster-inventory/README.md) and [Discussion doc](https://docs.google.com/document/d/1sUWbe81BTclQ4Uax3flnCoKtEWngH-JA9MyCqljJCBM/).
+The Cluster Inventory API is a part of [SIG Multicluster](https://github.com/kubernetes/community/tree/master/sig-multicluster),
+and this repository serves as the foundation for developing a standardized,
+robust framework for multi-cluster management in a cloud-native environment.
+
+The Cluster Inventory API aims to provide a consistent and automated approach for applications,
+frameworks, and toolsets to discover and interact with multiple Kubernetes clusters.
+The concept of Cluster Inventory is akin to service discovery in a microservices architecture.
+It allows multi-cluster applications to dynamically discover available clusters and respond to various cluster lifecycle events.
+Such events include auto-scaling, upgrades, failures, and connectivity issues.
+This automated inventory management not only facilitates operational efficiency
+but also supports the integration of diverse multi-cluster management solutions.
+See the initial proposal in the [documentation](https://docs.google.com/document/d/1sUWbe81BTclQ4Uax3flnCoKtEWngH-JA9MyCqljJCBM/)
+for more details.
+
+## Cluster Profile API
+
+Within the broader Cluster Inventory, the first major component we are introducing is the
+[ClusterProfile API](https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/4322-cluster-inventory/README.md).
+A Cluster Profile is essentially an individual member of the Cluster Inventory that details the properties and status of a cluster.
+This API proposes a universal, standardized interface that defines how cluster information should be presented
+and interacted with across different platforms and implementations.
+
+### Motivation and Goals
+
+The `ClusterProfile API` is designed to establish a shared interface for cluster inventory,
+laying the groundwork for multi-cluster tooling by providing a foundational component.
+Here are several key benefits and purposes of adopting the ClusterProfile API:
+
+- **Standardization**: By defining a standard for status reporting and cluster properties,
+the API facilitates a common understanding that can be shared across various tools and platforms.
+- **Ease of Integration**: Consumers of the API, such as multi-cluster workload schedulers and GitOps tools (e.g., ArgoCD, Kueue),
+can integrate without needing to navigate the specific implementation details of different cluster management projects.
+- **Vendor Neutrality**: The API provides a vendor-neutral integration point,
+allowing operations tools and external consumers to define and manage clusters across different cloud environments uniformly.
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION
The SIG-MC community has decided on the `Cluster Profile` renaming. This PR is to highlight the relationship between the Cluster Inventory and the Cluster Profile API.

It's assume that the KEP rename PR https://github.com/kubernetes/enhancements/pull/4533 will be merged shortly. 