### PR TITLE
Integrate EKS credentials and pod listing functionality Example

### DIFF
--- a/pkg/controller_example.go
+++ b/pkg/controller_example.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
+	"encoding/base64"
 	"flag"
 	"log"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
@@ -18,6 +22,12 @@ func main() {
 		log.Fatalf("Got error reading credentials providers: %v", err)
 	}
 
+	caPEMBase64 := `LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1J...`
+	caPEM, err := base64.StdEncoding.DecodeString(caPEMBase64)
+	if err != nil {
+		log.Fatalf("CA PEM base64 decode failed: %v", err)
+	}
+
 	// normally we would get this clusterprofile from the local cluster (maybe a watch?)
 	// and we would maintain the restconfigs for clusters we're interested in.
 	exampleClusterProfile := v1alpha1.ClusterProfile{
@@ -27,9 +37,10 @@ func main() {
 		Status: v1alpha1.ClusterProfileStatus{
 			CredentialProviders: []v1alpha1.CredentialProvider{
 				{
-					Name: "gkeFleet",
+					Name: "eks",
 					Cluster: clientcmdv1.Cluster{
-						Server: "https://myserver.tld:443",
+						Server: "https://xxx.gr7.ap-northeast-1.eks.amazonaws.com",
+						CertificateAuthorityData: caPEM,
 					},
 				},
 			},
@@ -42,4 +53,23 @@ func main() {
 	}
 	log.Printf("Got credentials: %v", restConfigForMyCluster)
 	// I can then use this rest.Config to build a k8s client.
+
+	// Build a client and list Pods in the default namespace
+	clientset, err := kubernetes.NewForConfig(restConfigForMyCluster)
+	if err != nil {
+		log.Fatalf("failed to create clientset: %v", err)
+	}
+	ctx := context.Background()
+	pods, err := clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Fatalf("failed to list pods: %v", err)
+	}
+	log.Printf("default namespace has %d pods", len(pods.Items))
+	for i, p := range pods.Items {
+		if i >= 10 {
+			log.Printf("... (truncated)")
+			break
+		}
+		log.Printf("pod: %s", p.Name)
+	}
 }

--- a/pkg/cp-creds.json
+++ b/pkg/cp-creds.json
@@ -1,11 +1,11 @@
 {
   "providers": [
     {
-      "name": "gkeFleet",
+      "name": "eks",
       "execConfig": {
           "apiVersion": "client.authentication.k8s.io/v1beta1",
           "args": null,
-          "command": "gke-gcloud-auth-plugin",
+          "command": "./eks-aws-auth-plugin.sh",
           "env": null,
           "provideClusterInfo": true
       }

--- a/pkg/eks-aws-auth-plugin.sh
+++ b/pkg/eks-aws-auth-plugin.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -------- utils --------
+err() { printf "[eks-exec-credential] %s\n" "$*" >&2; }
+need() { command -v "$1" >/dev/null 2>&1 || { err "missing dependency: $1"; exit 1; }; }
+normalize_host() { sed -E 's#^https?://##; s#/$##; s#:443$##'; }
+
+need jq
+need aws
+
+# --- read ExecCredential ---
+if [[ -z "${KUBERNETES_EXEC_INFO:-}" ]]; then
+  err "KUBERNETES_EXEC_INFO is empty. set provideClusterInfo: true"
+  exit 1
+fi
+
+REQ_API_VERSION="$(jq -r '.apiVersion // empty' <<<"$KUBERNETES_EXEC_INFO")"
+SERVER="$(jq -r '.spec.cluster.server // empty' <<<"$KUBERNETES_EXEC_INFO")"
+if [[ -z "$SERVER" || "$SERVER" == "null" ]]; then
+  err "spec.cluster.server is missing in KUBERNETES_EXEC_INFO"
+  exit 1
+fi
+
+NORM_SERVER="$(printf "%s" "$SERVER" | normalize_host)"
+
+# --- region: infer from server hostname ---
+HOST="${NORM_SERVER%%/*}"
+REGION="$(printf "%s\n" "$HOST" \
+  | sed -nE 's#.*\.([a-z0-9-]+)\.eks(-fips)?\.amazonaws\.com(\.cn)?$#\1#p')"
+if [[ -z "$REGION" ]]; then
+  err "failed to parse region from server hostname: ${SERVER}"
+  err "expected something like ...<random>.<suffix>.<region>.eks.amazonaws.com"
+  exit 1
+fi
+
+# --- tiny cache: endpoint -> cluster name ---
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/eks-exec-credential"
+mkdir -p "$CACHE_DIR"
+MAP_CACHE="$CACHE_DIR/endpoint-map-${REGION}.json"
+if [[ ! -s "$MAP_CACHE" ]] || ! jq -e . >/dev/null 2>&1 <"$MAP_CACHE"; then
+  echo '{}' >"$MAP_CACHE"
+fi
+
+lookup_cache() { jq -r --arg k "$NORM_SERVER" '.[$k] // empty' <"$MAP_CACHE"; }
+update_cache() {
+  local tmp; tmp="$(mktemp)"
+  jq --arg k "$NORM_SERVER" --arg v "$1" '.[$k]=$v' "$MAP_CACHE" >"$tmp" && mv "$tmp" "$MAP_CACHE"
+}
+
+match_endpoint() {
+  local name="$1"
+  local ep norm_ep
+  ep="$(aws eks describe-cluster --region "$REGION" --name "$name" \
+        --query 'cluster.endpoint' --output text 2>/dev/null || true)"
+  [[ -z "$ep" || "$ep" == "None" ]] && return 1
+  norm_ep="$(printf "%s" "$ep" | normalize_host)"
+  [[ "$norm_ep" == "$NORM_SERVER" ]]
+}
+
+CLUSTER_NAME=""
+# 1) cache hit?
+CACHED="$(lookup_cache || true)"
+if [[ -n "$CACHED" ]] && match_endpoint "$CACHED"; then
+  CLUSTER_NAME="$CACHED"
+fi
+
+# 2) enumerate if needed
+if [[ -z "$CLUSTER_NAME" ]]; then
+  err "resolving cluster in ${REGION} for ${NORM_SERVER}"
+  found=""
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if match_endpoint "$name"; then
+      found="$name"
+      break
+    fi
+  done < <(aws eks list-clusters --region "$REGION" --output json | jq -r '.clusters[]?')
+
+  if [[ -z "$found" ]]; then
+    err "no matching EKS cluster for endpoint: ${SERVER} (region=${REGION})"
+    exit 1
+  fi
+  CLUSTER_NAME="$found"
+  update_cache "$CLUSTER_NAME" || true
+fi
+
+# --- fetch ExecCredential via aws CLI ---
+TOKEN_JSON="$(aws eks get-token --region "$REGION" --cluster-name "$CLUSTER_NAME" --output json)"
+
+printf "%s\n" "$TOKEN_JSON"


### PR DESCRIPTION
- Convert CredentialProvider name to "eks".
- Implement eks-aws-auth-plugin.sh for AWS authentication.
- Utilize rest.Config to create a Kubernetes client.
- List pods in the "default" namespace from the EKS cluster.