### PR TITLE
Add controller-runtime client example and rename credentialProviders to accessProviders

### DIFF
--- a/cmd/secretreader-plugin/README.md
+++ b/cmd/secretreader-plugin/README.md
@@ -57,7 +57,7 @@ Use the following provider config to exec the secret-reader plugin.
 }
 ```
 
-### Note: `ClusterProfile.status.credentialProviders[].cluster.extensions`
+### Note: `ClusterProfile.status.accessProviders[].cluster.extensions`
 
 - Required: set `extensions[].name` to `client.authentication.k8s.io/exec`.
 - The library reads only the `extension` field of that entry and passes it through to `ExecCredential.Spec.Cluster.Config`.
@@ -67,7 +67,7 @@ Example:
 
 ```yaml
 status:
-  credentialProviders:
+  accessProviders:
   - name: secretreader
     cluster:
       server: https://<spoke-server>

--- a/examples/controller-example/README.md
+++ b/examples/controller-example/README.md
@@ -5,7 +5,7 @@ This example automatically sets up the following, stores the spoke cluster token
 - Create a hub cluster and a spoke cluster with kind
 - On the spoke, create a ServiceAccount and ClusterRole/Binding that can list Pods and issue a token
 - On the hub, create a Secret with the token in `data.token`
-- On the hub, create a `ClusterProfile` with spoke information (set `secretreader` in `status.credentialProviders`)
+- On the hub, create a `ClusterProfile` with spoke information (set `secretreader` in `status.accessProviders`)
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ KUBECONFIG=./examples/controller-example/hub.kubeconfig ./examples/controller-ex
 
 ## Note: ClusterProfile extensions
 
-- Required: set `status.credentialProviders[].cluster.extensions[].name` to `client.authentication.k8s.io/exec`.
+- Required: set `status.accessProviders[].cluster.extensions[].name` to `client.authentication.k8s.io/exec`.
 - The library reads only the `extension` field of that entry (arbitrary JSON). Other `extensions` entries are ignored.
 - That `extension` is passed through to `ExecCredential.Spec.Cluster.Config`. The `secretreader` plugin uses `clusterName` in that object.
 
@@ -51,7 +51,7 @@ Example (to be merged into `ClusterProfile.status`):
 
 ```yaml
 status:
-  credentialProviders:
+  accessProviders:
   - name: secretreader
     cluster:
       server: https://<spoke-server>

--- a/examples/controller-example/main.go
+++ b/examples/controller-example/main.go
@@ -18,7 +18,7 @@ import (
 
 func main() {
 	// Flags
-	credentialsProviders := credentials.SetupProviderFileFlag()
+	accessProviders := credentials.SetupProviderFileFlag()
 	namespace := flag.String("namespace", "default", "Namespace of the ClusterProfile on the hub cluster")
 	clusterProfileName := flag.String("clusterprofile", "", "Name of the ClusterProfile to target (required)")
 	flag.Parse()
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	// Load providers file
-	cpCreds, err := credentials.NewFromFile(*credentialsProviders)
+	cpCreds, err := credentials.NewFromFile(*accessProviders)
 	if err != nil {
 		log.Fatalf("Got error reading credentials providers: %v", err)
 	}

--- a/examples/controller-example/setup-kind-demo.sh
+++ b/examples/controller-example/setup-kind-demo.sh
@@ -125,7 +125,7 @@ EOF
 STATUS_PATCH=$(cat <<EOF
 {
   "status": {
-    "credentialProviders": [
+    "accessProviders": [
       {
         "name": "secretreader",
         "cluster": {


### PR DESCRIPTION
## Summary  

This PR introduces a working example that uses the controller-runtime client to interact with ClusterProfile CRDs, and renames credentialProviders to accessProviders for clearer terminology and consistency.

## Motivation  

- Provide a canonical, minimal example for consumers who prefer `controller-runtime` over raw client-go.
- Align naming with the “access providers”

## Release notes

```
- Add controller-runtime client example under examples/controller-example
- Rename credentialProviders to accessProviders
```
