### PR TITLE
Add corentone to OWNERS reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,4 +14,5 @@ reviewers:
   - ryanzhang-oss
   - qiujian16
   - skitt
+  - corentone
   - kahirokunn


### PR DESCRIPTION
Corentone is not yet a member of the org.
This PR is a continuation of the following PR:
https://github.com/kubernetes-sigs/cluster-inventory-api/pull/31

I will bring the OWNERS file closer to reality. 
