### PR TITLE
Rename credentials to access

### DIFF
--- a/examples/controller-example/main.go
+++ b/examples/controller-example/main.go
@@ -13,13 +13,13 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ciaclient "sigs.k8s.io/cluster-inventory-api/client/clientset/versioned"
-	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
+	"sigs.k8s.io/cluster-inventory-api/pkg/access"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func main() {
 	// Flags
-	accessProviders := credentials.SetupProviderFileFlag()
+	providerFile := access.SetupProviderFileFlag()
 	namespace := flag.String("namespace", "default", "Namespace of the ClusterProfile on the hub cluster")
 	clusterProfileName := flag.String("clusterprofile", "", "Name of the ClusterProfile to target (required)")
 	flag.Parse()
@@ -29,9 +29,9 @@ func main() {
 	}
 
 	// Load providers file
-	cpCreds, err := credentials.NewFromFile(*accessProviders)
+	accessCfg, err := access.NewFromFile(*providerFile)
 	if err != nil {
-		log.Fatalf("Got error reading credentials providers: %v", err)
+		log.Fatalf("Got error reading access providers: %v", err)
 	}
 
 	// Build hub client and get ClusterProfile (in-cluster first, then kubeconfig)
@@ -55,8 +55,8 @@ func main() {
 		log.Fatalf("failed to get ClusterProfile %s/%s: %v", *namespace, *clusterProfileName, err)
 	}
 
-	// Build rest.Config for the spoke cluster using the credential provider
-	spokeConfig, err := cpCreds.BuildConfigFromCP(cp)
+	// Build rest.Config for the spoke cluster using the access config
+	spokeConfig, err := accessCfg.BuildConfigFromCP(cp)
 	if err != nil {
 		log.Fatalf("Got error generating spoke rest.Config: %v", err)
 	}

--- a/examples/controller-example/plugins/kubelogin/main.go
+++ b/examples/controller-example/plugins/kubelogin/main.go
@@ -10,7 +10,7 @@ import (
 	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
-	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
+	"sigs.k8s.io/cluster-inventory-api/pkg/access"
 )
 
 // The example below showcases how to use Azure's kubelogin exec plugin to sign into an
@@ -21,7 +21,7 @@ import (
 // and/or environment variables to the exec plugin via the ClusterProfile API using the
 // reserved extensions, as defined in KEP 5339.
 func main() {
-	providers := []credentials.Provider{
+	providers := []access.Provider{
 		{
 			Name: "aks-workload-identity",
 			ExecConfig: &clientcmdapi.ExecConfig{
@@ -42,11 +42,11 @@ func main() {
 				ProvideClusterInfo: false,
 				InteractiveMode:    clientcmdapi.NeverExecInteractiveMode,
 			},
-			ProfileSourcedCLIArgsPolicy: credentials.ProfileSourcedCLIArgsPolicyAppend,
-			ProfileSourcedEnvVarsPolicy: credentials.ProfileSourcedEnvVarsPolicyReplace,
+			ProfileSourcedCLIArgsPolicy: access.ProfileSourcedCLIArgsPolicyAppend,
+			ProfileSourcedEnvVarsPolicy: access.ProfileSourcedEnvVarsPolicyReplace,
 		},
 	}
-	cps := credentials.New(providers)
+	accessCfg := access.New(providers)
 
 	// The additional arguments are cluster-specific information.
 	additionalArgs := []string{
@@ -110,7 +110,7 @@ func main() {
 		},
 	}
 
-	restConfig, err := cps.BuildConfigFromCP(profile)
+	restConfig, err := accessCfg.BuildConfigFromCP(profile)
 	if err != nil {
 		log.Fatalf("Failed to prepare REST config: %v", err)
 	}

--- a/pkg/access/config.go
+++ b/pkg/access/config.go
@@ -1,3 +1,31 @@
+// Package access provides configuration for building Kubernetes REST configs
+// from ClusterProfile resources.
+//
+// This package is used by controllers that need to connect to "spoke" clusters
+// registered in a cluster inventory. It reads a provider configuration file
+// (typically passed via the --clusterprofile-provider-file flag), matches
+// providers against the AccessProviders listed in a ClusterProfile's status,
+// and produces a [rest.Config] ready for use with client-go.
+//
+// Note: This package is unrelated to Kubernetes RBAC or access control.
+// It manages cluster access configuration via exec-based authentication plugins.
+//
+// Basic usage:
+//
+//	// Load provider configuration from a JSON file
+//	cfg, err := access.NewFromFile("clusterprofile-provider-file.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Build a rest.Config for a specific ClusterProfile
+//	restConfig, err := cfg.BuildConfigFromCP(clusterProfile)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Use restConfig with client-go
+//	client, err := kubernetes.NewForConfig(restConfig)
 package access
 
 import (

--- a/pkg/access/config.go
+++ b/pkg/access/config.go
@@ -1,4 +1,4 @@
-package credentials
+package access
 
 import (
 	"encoding/json"
@@ -55,12 +55,12 @@ type Provider struct {
 	ProfileSourcedEnvVarsPolicy ProfileSourcedEnvVarsPolicy `json:"profileSourcedEnvVarsPolicy,omitempty"`
 }
 
-type CredentialsProvider struct {
+type Config struct {
 	Providers []Provider `json:"providers"`
 }
 
-func New(providers []Provider) *CredentialsProvider {
-	return &CredentialsProvider{
+func New(providers []Provider) *Config {
+	return &Config{
 		Providers: providers,
 	}
 }
@@ -76,37 +76,37 @@ func SetupProviderFileFlag() *string {
 	)
 }
 
-func NewFromFile(path string) (*CredentialsProvider, error) {
+func NewFromFile(path string) (*Config, error) {
 	// 1. Read the file's content
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read credentials file: %w", err)
+		return nil, fmt.Errorf("failed to read access config file: %w", err)
 	}
 
 	// 2. Create a new Providers instance and unmarshal the data into it
-	var providers CredentialsProvider
+	var providers Config
 	if err := json.Unmarshal(data, &providers); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal credential providers: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal access providers: %w", err)
 	}
 
-	// 3. Return the populated credentials
+	// 3. Return the populated access config
 	return &providers, nil
 }
 
 // BuildConfigFromCP builds a rest.Config from the given ClusterProfile
-func (cp *CredentialsProvider) BuildConfigFromCP(clusterprofile *v1alpha1.ClusterProfile) (*rest.Config, error) {
+func (c *Config) BuildConfigFromCP(clusterprofile *v1alpha1.ClusterProfile) (*rest.Config, error) {
 	// 1. obtain the correct clusterAccessor from the CP
-	clusterAccessor := cp.getClusterAccessorFromClusterProfile(clusterprofile)
+	clusterAccessor := c.getClusterAccessorFromClusterProfile(clusterprofile)
 	if clusterAccessor == nil {
 		return nil, fmt.Errorf("no matching cluster accessor found for cluster profile %q", clusterprofile.Name)
 	}
 
 	// 2. Get Exec Config
 	execConfig, cliArgsPolicy, envVarsPolicy :=
-		cp.getExecConfigAndFlagsFromConfig(clusterAccessor.Name)
+		c.getExecConfigAndFlagsFromConfig(clusterAccessor.Name)
 	if execConfig == nil {
 		return nil, fmt.Errorf(
-			"no exec credentials found for provider %q",
+			"no exec config found for provider %q",
 			clusterAccessor.Name,
 		)
 	}
@@ -132,7 +132,7 @@ func (cp *CredentialsProvider) BuildConfigFromCP(clusterprofile *v1alpha1.Cluste
 		}
 	}
 
-	// 3. build resulting rest.Config
+	// 4. build resulting rest.Config
 	config := &rest.Config{
 		Host: clusterAccessor.Cluster.Server,
 		TLSClientConfig: rest.TLSClientConfig{
@@ -168,10 +168,10 @@ func (cp *CredentialsProvider) BuildConfigFromCP(clusterprofile *v1alpha1.Cluste
 	return config, nil
 }
 
-func (cp *CredentialsProvider) getExecConfigAndFlagsFromConfig(
+func (c *Config) getExecConfigAndFlagsFromConfig(
 	providerName string,
 ) (*clientcmdapi.ExecConfig, ProfileSourcedCLIArgsPolicy, ProfileSourcedEnvVarsPolicy) {
-	for _, provider := range cp.Providers {
+	for _, provider := range c.Providers {
 		if provider.Name == providerName {
 			return provider.ExecConfig, provider.ProfileSourcedCLIArgsPolicy, provider.ProfileSourcedEnvVarsPolicy
 		}
@@ -180,8 +180,8 @@ func (cp *CredentialsProvider) getExecConfigAndFlagsFromConfig(
 }
 
 // getClusterAccessorFromClusterProfile returns the first AccessProvider from the ClusterProfile
-// that matches one of the supported provider types in the CredentialsProvider
-func (cp *CredentialsProvider) getClusterAccessorFromClusterProfile(
+// that matches one of the supported provider types in the Config
+func (c *Config) getClusterAccessorFromClusterProfile(
 	cluster *v1alpha1.ClusterProfile,
 ) *v1alpha1.AccessProvider {
 	accessProviderTypes := map[string]*v1alpha1.AccessProvider{}
@@ -199,8 +199,8 @@ func (cp *CredentialsProvider) getClusterAccessorFromClusterProfile(
 		accessProviderTypes[accessProvider.Name] = accessProvider.DeepCopy()
 	}
 
-	// we return the first access provider that the CredentialsProvider supports.
-	for _, providerType := range cp.Providers {
+	// we return the first access provider that the Config supports.
+	for _, providerType := range c.Providers {
 		if accessor, found := accessProviderTypes[providerType.Name]; found {
 			return accessor
 		}

--- a/pkg/access/config_test.go
+++ b/pkg/access/config_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package credentials
+package access
 
 import (
 	"encoding/json"
@@ -36,21 +36,21 @@ import (
 
 const providerLocalEnvVarDefault = "None"
 
-func TestCredentials(t *testing.T) {
+func TestAccess(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Credentials Package Suite")
+	ginkgo.RunSpecs(t, "Access Package Suite")
 }
 
-var _ = ginkgo.Describe("CredentialsProvider", func() {
+var _ = ginkgo.Describe("Config", func() {
 	var (
-		tempDir             string
-		testProviders       []Provider
-		credentialsProvider *CredentialsProvider
+		tempDir       string
+		testProviders []Provider
+		cfg           *Config
 	)
 
 	ginkgo.BeforeEach(func() {
 		var err error
-		tempDir, err = os.MkdirTemp("", "credentials-test")
+		tempDir, err = os.MkdirTemp("", "access-test")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		testProviders = []Provider{
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 				ProfileSourcedEnvVarsPolicy: ProfileSourcedEnvVarsPolicyReplace,
 			},
 		}
-		credentialsProvider = New(testProviders)
+		cfg = New(testProviders)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 	})
 
 	ginkgo.Describe("New", func() {
-		ginkgo.It("should create a new CredentialsProvider with provided providers", func() {
+		ginkgo.It("should create a new Config with provided providers", func() {
 			providers := []Provider{
 				{Name: "provider1", ExecConfig: &clientcmdapi.ExecConfig{Command: "cmd1"}},
 				{Name: "provider2", ExecConfig: &clientcmdapi.ExecConfig{Command: "cmd2"}},
@@ -96,13 +96,13 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 			gomega.Expect(cp.Providers[1].Name).To(gomega.Equal("provider2"))
 		})
 
-		ginkgo.It("should create a CredentialsProvider with empty providers", func() {
+		ginkgo.It("should create a Config with empty providers", func() {
 			cp := New([]Provider{})
 			gomega.Expect(cp).NotTo(gomega.BeNil())
 			gomega.Expect(cp.Providers).To(gomega.HaveLen(0))
 		})
 
-		ginkgo.It("should create a CredentialsProvider with nil providers", func() {
+		ginkgo.It("should create a Config with nil providers", func() {
 			cp := New(nil)
 			gomega.Expect(cp).NotTo(gomega.BeNil())
 			gomega.Expect(cp.Providers).To(gomega.BeNil())
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 	ginkgo.Describe("NewFromFile", func() {
 		ginkgo.It("should successfully read and unmarshal a valid JSON file", func() {
 			// Create a test JSON file
-			testData := CredentialsProvider{
+			testData := Config{
 				Providers: []Provider{
 					{
 						Name: "gkeFleet",
@@ -165,7 +165,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 			cp, err := NewFromFile(nonExistentFile)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(cp).To(gomega.BeNil())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to read credentials file"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to read access config file"))
 		})
 
 		ginkgo.It("should return an error when file contains invalid JSON", func() {
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 			cp, err := NewFromFile(invalidJSONFile)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(cp).To(gomega.BeNil())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to unmarshal credential providers"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to unmarshal access providers"))
 		})
 
 		ginkgo.It("should handle empty JSON file", func() {
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 	ginkgo.Describe("getExecConfigFromConfig", func() {
 		ginkgo.It("should return the correct ExecConfig for existing provider", func() {
 			execConfig, cliArgsPolicy, envVarsPolicy :=
-				credentialsProvider.getExecConfigAndFlagsFromConfig(
+				cfg.getExecConfigAndFlagsFromConfig(
 					"test-provider-1",
 				)
 			gomega.Expect(execConfig).NotTo(gomega.BeNil())
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 
 		ginkgo.It("should return the correct ExecConfig for another existing provider", func() {
 			execConfig, cliArgsPolicy, envVarsPolicy :=
-				credentialsProvider.getExecConfigAndFlagsFromConfig(
+				cfg.getExecConfigAndFlagsFromConfig(
 					"test-provider-2",
 				)
 			gomega.Expect(execConfig).NotTo(gomega.BeNil())
@@ -230,7 +230,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 
 		ginkgo.It("should return nil for non-existing provider", func() {
 			execConfig, cliArgsPolicy, envVarsPolicy :=
-				credentialsProvider.getExecConfigAndFlagsFromConfig(
+				cfg.getExecConfigAndFlagsFromConfig(
 					"non-existent-provider",
 				)
 			gomega.Expect(execConfig).To(gomega.BeNil())
@@ -244,7 +244,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 
 		ginkgo.It("should return nil for empty provider name", func() {
 			execConfig, cliArgsPolicy, envVarsPolicy :=
-				credentialsProvider.getExecConfigAndFlagsFromConfig("")
+				cfg.getExecConfigAndFlagsFromConfig("")
 			gomega.Expect(execConfig).To(gomega.BeNil())
 			gomega.Expect(cliArgsPolicy).To(
 				gomega.Equal(ProfileSourcedCLIArgsPolicyIgnore),
@@ -254,7 +254,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 			)
 		})
 
-		ginkgo.It("should handle CredentialsProvider with no providers", func() {
+		ginkgo.It("should handle Config with no providers", func() {
 			emptyCP := New([]Provider{})
 			execConfig, cliArgsPolicy, envVarsPolicy :=
 				emptyCP.getExecConfigAndFlagsFromConfig(
@@ -306,14 +306,14 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 		})
 
 		ginkgo.It("should return the first matching provider", func() {
-			provider := credentialsProvider.getClusterAccessorFromClusterProfile(clusterProfile)
+			provider := cfg.getClusterAccessorFromClusterProfile(clusterProfile)
 			gomega.Expect(provider).NotTo(gomega.BeNil())
 			gomega.Expect(provider.Name).To(gomega.Equal("test-provider-1"))
 			gomega.Expect(provider.Cluster.Server).To(gomega.Equal("https://test-server-1.com"))
 		})
 
 		ginkgo.It("should return nil when no matching provider is found", func() {
-			// Create a CredentialsProvider with providers that don't match the ClusterProfile
+			// Create a Config with providers that don't match the ClusterProfile
 			mismatchedCP := New([]Provider{
 				{Name: "different-provider", ExecConfig: &clientcmdapi.ExecConfig{Command: "cmd"}},
 			})
@@ -321,17 +321,17 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 			gomega.Expect(provider).To(gomega.BeNil())
 		})
 
-		ginkgo.It("should handle ClusterProfile with no credential providers", func() {
+		ginkgo.It("should handle ClusterProfile with no access providers", func() {
 			emptyClusterProfile := &v1alpha1.ClusterProfile{
 				ObjectMeta: metav1.ObjectMeta{Name: "empty-cluster"},
 				Status:     v1alpha1.ClusterProfileStatus{},
 			}
-			provider := credentialsProvider.getClusterAccessorFromClusterProfile(emptyClusterProfile)
+			provider := cfg.getClusterAccessorFromClusterProfile(emptyClusterProfile)
 			gomega.Expect(provider).To(gomega.BeNil())
 		})
 
 		ginkgo.It("should return a deep copy of the provider", func() {
-			provider := credentialsProvider.getClusterAccessorFromClusterProfile(clusterProfile)
+			provider := cfg.getClusterAccessorFromClusterProfile(clusterProfile)
 			gomega.Expect(provider).NotTo(gomega.BeNil())
 
 			// Modify the original cluster profile
@@ -397,7 +397,7 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 		})
 
 		ginkgo.It("should return an error when no matching provider is found", func() {
-			// Create a CredentialsProvider with providers that don't match the ClusterProfile
+			// Create a Config with providers that don't match the ClusterProfile
 			mismatchedCP := New([]Provider{
 				{Name: "different-provider", ExecConfig: &clientcmdapi.ExecConfig{Command: "cmd"}},
 			})
@@ -408,14 +408,14 @@ var _ = ginkgo.Describe("CredentialsProvider", func() {
 		})
 
 		ginkgo.It("should return an error when no exec config is found", func() {
-			// Create a CredentialsProvider with matching provider name but no ExecConfig
+			// Create a Config with matching provider name but no ExecConfig
 			noExecCP := New([]Provider{
 				{Name: "test-provider-1", ExecConfig: nil},
 			})
 			config, err := noExecCP.BuildConfigFromCP(clusterProfile)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(config).To(gomega.BeNil())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("no exec credentials found for provider"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("no exec config found for provider"))
 		})
 
 		ginkgo.It("should build config successfully (no additional CLI args/env vars)", func() {

--- a/pkg/examples/controller/main.go
+++ b/pkg/examples/controller/main.go
@@ -6,16 +6,16 @@ import (
 
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
-	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
+	"sigs.k8s.io/cluster-inventory-api/pkg/access"
 )
 
 func main() {
-	credentialsProviders := credentials.SetupProviderFileFlag()
+	providerFile := access.SetupProviderFileFlag()
 	flag.Parse()
 
-	cpCreds, err := credentials.NewFromFile(*credentialsProviders)
+	accessCfg, err := access.NewFromFile(*providerFile)
 	if err != nil {
-		log.Fatalf("Got error reading credentials providers: %v", err)
+		log.Fatalf("Got error reading access providers: %v", err)
 	}
 
 	// normally we would get this clusterprofile from the local cluster (maybe a watch?)
@@ -36,10 +36,10 @@ func main() {
 		},
 	}
 
-	restConfigForMyCluster, err := cpCreds.BuildConfigFromCP(&exampleClusterProfile)
+	restConfigForMyCluster, err := accessCfg.BuildConfigFromCP(&exampleClusterProfile)
 	if err != nil {
 		log.Fatalf("Got error generating restConfig: %v", err)
 	}
-	log.Printf("Got credentials: %v", restConfigForMyCluster)
+	log.Printf("Got rest.Config: %v", restConfigForMyCluster)
 	// I can then use this rest.Config to build a k8s client.
 }

--- a/test/integration/access_test.go
+++ b/test/integration/access_test.go
@@ -16,11 +16,11 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
-	"sigs.k8s.io/cluster-inventory-api/pkg/credentials"
+	"sigs.k8s.io/cluster-inventory-api/pkg/access"
 	"sigs.k8s.io/yaml"
 )
 
-var _ = ginkgo.Describe("Credentials test", func() {
+var _ = ginkgo.Describe("Access config test", func() {
 	var clusterName string
 	var clusterManagerName string
 	var tempDir string
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("Credentials test", func() {
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		tempDir, err = os.MkdirTemp("", "integration-credentials-test")
+		tempDir, err = os.MkdirTemp("", "integration-access-test")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("Credentials test", func() {
 		}
 	})
 
-	ginkgo.It("Should get credntial by cluster profile", func() {
+	ginkgo.It("Should get access config by cluster profile", func() {
 		cp, err := clusterProfileClient.ApisV1alpha1().ClusterProfiles(testNamespace).Get(
 			context.TODO(), clusterName, metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -105,8 +105,8 @@ var _ = ginkgo.Describe("Credentials test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Create provider configuration file
-		credProviderConfig := credentials.CredentialsProvider{
-			Providers: []credentials.Provider{
+		providerConfig := access.Config{
+			Providers: []access.Provider{
 				{
 					Name: "provider1",
 					ExecConfig: &clientcmdapi.ExecConfig{
@@ -119,17 +119,17 @@ var _ = ginkgo.Describe("Credentials test", func() {
 			},
 		}
 
-		credProviderData, err := json.Marshal(credProviderConfig)
+		providerData, err := json.Marshal(providerConfig)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		configFile := filepath.Join(tempDir, "test-config.json")
-		err = os.WriteFile(configFile, credProviderData, 0644)
+		err = os.WriteFile(configFile, providerData, 0644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		credentialConfig, err := credentials.NewFromFile(configFile)
+		accessCfg, err := access.NewFromFile(configFile)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		config, err := credentialConfig.BuildConfigFromCP(cp)
+		config, err := accessCfg.BuildConfigFromCP(cp)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(config).NotTo(gomega.BeNil())
 


### PR DESCRIPTION
## Summary

Following the `CredentialsProvider` → `AccessProvider` rename at the CRD level, I'd like to propagate the same change to the existing code and sample manifests for consistency.
