### PR TITLE
refactor(plugins): simplify namespace inference and harden e2e

### DIFF
--- a/examples/controller-example/plugins/kubeconfig-secretreader/README.md
+++ b/examples/controller-example/plugins/kubeconfig-secretreader/README.md
@@ -43,7 +43,7 @@ make build-controller-example
 ```bash
 KUBECONFIG=./examples/controller-example/hub.kubeconfig ./examples/controller-example/controller-example.bin \
   -clusterprofile-provider-file ./examples/controller-example/plugins/kubeconfig-secretreader/provider-config.json \
-  -namespace default \
+  -namespace fleet \
   -clusterprofile spoke-1
 ```
 

--- a/examples/controller-example/plugins/kubeconfig-secretreader/setup-kind-demo.sh
+++ b/examples/controller-example/plugins/kubeconfig-secretreader/setup-kind-demo.sh
@@ -84,17 +84,20 @@ users:
 EOF
 )
 
+kubectl --context "kind-hub" create namespace "spoke-manager" --dry-run=client -o yaml | kubectl --context "kind-hub" apply -f -
 kubectl --context "kind-hub" create secret generic "spoke-1-kubeconfig" \
+  --namespace spoke-manager \
   --from-literal=value="${KUBECONFIG_YAML}" \
   --dry-run=client -o yaml | kubectl --context "kind-hub" apply -f -
 
 echo "[7/7] Create ClusterProfile on hub cluster and patch status with provider"
+kubectl --context "kind-hub" create namespace "fleet" --dry-run=client -o yaml | kubectl --context "kind-hub" apply -f -
 kubectl --context "kind-hub" apply -f - <<EOF
 apiVersion: multicluster.x-k8s.io/v1alpha1
 kind: ClusterProfile
 metadata:
   name: spoke-1
-  namespace: default
+  namespace: fleet
 spec:
   clusterManager:
     name: demo
@@ -115,7 +118,7 @@ STATUS_PATCH=$(cat <<EOF
               "extension": {
                 "name": "spoke-1-kubeconfig",
                 "key": "value",
-                "namespace": "default",
+                "namespace": "spoke-manager",
                 "context": "${CONTEXT_NAME}"
               }
             }
@@ -128,5 +131,5 @@ STATUS_PATCH=$(cat <<EOF
 EOF
 )
 
-kubectl --context "kind-hub" patch clusterprofile "spoke-1" --type=merge --subresource=status -p "${STATUS_PATCH}"
+kubectl --context "kind-hub" patch clusterprofile "spoke-1" -n fleet --type=merge --subresource=status -p "${STATUS_PATCH}"
 

--- a/examples/controller-example/plugins/secretreader/README.md
+++ b/examples/controller-example/plugins/secretreader/README.md
@@ -43,7 +43,7 @@ make build-controller-example
 ```bash
 KUBECONFIG=./examples/controller-example/hub.kubeconfig ./examples/controller-example/controller-example.bin \
   -clusterprofile-provider-file ./examples/controller-example/plugins/secretreader/provider-config.json \
-  -namespace default \
+  -namespace fleet \
   -clusterprofile spoke-1
 ```
 

--- a/examples/controller-example/plugins/secretreader/setup-kind-demo.sh
+++ b/examples/controller-example/plugins/secretreader/setup-kind-demo.sh
@@ -106,18 +106,21 @@ kind get kubeconfig --name "hub" > "${EXAMPLE_DIR}/hub.kubeconfig"
 echo "[7/9] Install ClusterProfile CRD on hub cluster"
 kubectl --context "kind-hub" apply -f "${REPO_ROOT}/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml"
 
-echo "[8/9] Create Secret on hub cluster with token"
+echo "[8/9] Create namespace and Secret on hub cluster with token"
+kubectl --context "kind-hub" create namespace "spoke-manager" --dry-run=client -o yaml | kubectl --context "kind-hub" apply -f -
 kubectl --context "kind-hub" create secret generic "spoke-1" \
+  --namespace spoke-manager \
   --from-literal=token="${TOKEN}" \
   --dry-run=client -o yaml | kubectl --context "kind-hub" apply -f -
 
 echo "[9/9] Create ClusterProfile on hub cluster and patch status with provider"
+kubectl --context "kind-hub" create namespace "fleet" --dry-run=client -o yaml | kubectl --context "kind-hub" apply -f -
 kubectl --context "kind-hub" apply -f - <<EOF
 apiVersion: multicluster.x-k8s.io/v1alpha1
 kind: ClusterProfile
 metadata:
   name: spoke-1
-  namespace: default
+  namespace: fleet
 spec:
   clusterManager:
     name: demo
@@ -148,5 +151,5 @@ STATUS_PATCH=$(cat <<EOF
 EOF
 )
 
-kubectl --context "kind-hub" patch clusterprofile "spoke-1" --type=merge --subresource=status -p "${STATUS_PATCH}"
+kubectl --context "kind-hub" patch clusterprofile "spoke-1" -n fleet --type=merge --subresource=status -p "${STATUS_PATCH}"
 

--- a/hack/e2e-controller-incluster.sh
+++ b/hack/e2e-controller-incluster.sh
@@ -32,6 +32,8 @@ cd "${REPO_ROOT}"
 PLUGIN_IMAGE="localhost/${PLUGIN_NAME}:e2e"
 CONTROLLER_IMAGE="localhost/controller-example:e2e"
 DEPLOY_NAME="controller-example"
+DEPLOY_NS="spoke-manager"
+PROFILE_NS="fleet"
 
 echo "--- Build plugin OCI image and load into hub"
 docker buildx build \
@@ -51,7 +53,7 @@ docker buildx build \
 kind load docker-image "${CONTROLLER_IMAGE}" --name hub
 
 echo "--- Patch ClusterProfile spoke-1 so spoke server is reachable from hub (spoke-control-plane:6443)"
-kubectl --context kind-hub patch clusterprofile spoke-1 --type=json --subresource=status \
+kubectl --context kind-hub patch clusterprofile spoke-1 -n "${PROFILE_NS}" --type=json --subresource=status \
 	-p '[{"op":"replace","path":"/status/accessProviders/0/cluster/server","value":"https://spoke-control-plane:6443"}]'
 
 echo "--- Apply RBAC for controller-example on hub"
@@ -60,17 +62,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-example
-  namespace: default
+  namespace: ${DEPLOY_NS}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: controller-example
-  namespace: default
+  namespace: ${DEPLOY_NS}
 rules:
-  - apiGroups: ["multicluster.x-k8s.io"]
-    resources: ["clusterprofiles"]
-    verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
@@ -79,7 +78,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: controller-example
-  namespace: default
+  namespace: ${DEPLOY_NS}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -87,11 +86,36 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: controller-example
-    namespace: default
+    namespace: ${DEPLOY_NS}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-example
+  namespace: ${PROFILE_NS}
+rules:
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources: ["clusterprofiles"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-example
+  namespace: ${PROFILE_NS}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-example
+subjects:
+  - kind: ServiceAccount
+    name: controller-example
+    namespace: ${DEPLOY_NS}
 EOF
 
 echo "--- Create provider-config ConfigMap (command stays ./bin/<name>-plugin; workingDir=/plugin)"
 kubectl --context kind-hub create configmap controller-example-provider-config \
+	--namespace "${DEPLOY_NS}" \
 	--from-file=provider-config.json="examples/controller-example/plugins/${PLUGIN_NAME}/provider-config.json" \
 	--dry-run=client -o yaml | kubectl --context kind-hub apply -f -
 
@@ -108,7 +132,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${DEPLOY_NAME}
-  namespace: default
+  namespace: ${DEPLOY_NS}
 spec:
   replicas: 1
   selector:
@@ -130,7 +154,7 @@ spec:
           workingDir: /plugin
           args:
             - -clusterprofile-provider-file=/config/provider-config.json
-            - -namespace=default
+            - -namespace=${PROFILE_NS}
             - -clusterprofile=spoke-1
           volumeMounts:
             - name: plugin-volume
@@ -153,18 +177,18 @@ spec:
 EOF
 
 echo "--- Wait for Pod to start and verify logs"
-kubectl --context kind-hub rollout status "deployment/${DEPLOY_NAME}" --timeout=120s || true
+kubectl --context kind-hub -n "${DEPLOY_NS}" rollout status "deployment/${DEPLOY_NAME}" --timeout=120s || true
 
 # Wait for at least one pod to have produced logs (it runs and exits quickly)
 POD=""
 for i in $(seq 1 60); do
-	POD=$(kubectl --context kind-hub get pods -l app=controller-example \
+	POD=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pods -l app=controller-example \
 		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
 	if [[ -n "${POD}" ]]; then
 		# Wait until the container has terminated at least once (exit code available)
-		TERMINATED=$(kubectl --context kind-hub get pod "${POD}" \
+		TERMINATED=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pod "${POD}" \
 			-o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}' 2>/dev/null || true)
-		STATE=$(kubectl --context kind-hub get pod "${POD}" \
+		STATE=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pod "${POD}" \
 			-o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' 2>/dev/null || true)
 		if [[ -n "${TERMINATED}" || -n "${STATE}" ]]; then
 			break
@@ -179,7 +203,7 @@ if [[ -z "${POD}" ]]; then
 	exit 1
 fi
 
-LOGS=$(kubectl --context kind-hub logs "${POD}" 2>&1)
+LOGS=$(kubectl --context kind-hub -n "${DEPLOY_NS}" logs "${POD}" 2>&1)
 echo "${LOGS}"
 
 if ! echo "${LOGS}" | grep -q "\[client-go\] Listed"; then

--- a/hack/e2e-controller-incluster.sh
+++ b/hack/e2e-controller-incluster.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# E2E: Run controller-example as a Deployment in the hub cluster with plugin OCI
+# E2E: Run controller-example as a Job in the hub cluster with plugin OCI
 # image mounted via image volume. Assumes hub and spoke kind clusters already
 # exist and setup-kind-demo.sh was run.
 # Usage: e2e-controller-incluster.sh <plugin_name> <provider_name>
@@ -126,23 +126,21 @@ if [[ -z "${SPOKE_IP}" ]]; then
 	exit 1
 fi
 
-echo "--- Create controller-example Deployment in hub"
+echo "--- Create controller-example Job in hub"
 kubectl --context kind-hub apply -f - <<EOF
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: ${DEPLOY_NAME}
   namespace: ${DEPLOY_NS}
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: controller-example
+  backoffLimit: 0
   template:
     metadata:
       labels:
         app: controller-example
     spec:
+      restartPolicy: Never
       serviceAccountName: controller-example
       hostAliases:
         - hostnames: ["spoke-control-plane"]
@@ -176,35 +174,52 @@ spec:
                 path: provider-config.json
 EOF
 
-echo "--- Wait for Pod to start and verify logs"
-kubectl --context kind-hub -n "${DEPLOY_NS}" rollout status "deployment/${DEPLOY_NAME}" --timeout=120s || true
-
-# Wait for at least one pod to have produced logs (it runs and exits quickly)
-POD=""
+echo "--- Wait for Job to finish"
+STATE=""
 for i in $(seq 1 60); do
-	POD=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pods -l app=controller-example \
-		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-	if [[ -n "${POD}" ]]; then
-		# Wait until the container has terminated at least once (exit code available)
-		TERMINATED=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pod "${POD}" \
-			-o jsonpath='{.status.containerStatuses[0].lastState.terminated.reason}' 2>/dev/null || true)
-		STATE=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pod "${POD}" \
-			-o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' 2>/dev/null || true)
-		if [[ -n "${TERMINATED}" || -n "${STATE}" ]]; then
-			break
-		fi
+	COMPLETE=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get "job/${DEPLOY_NAME}" \
+		-o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)
+	if [[ "${COMPLETE}" == "True" ]]; then
+		STATE="complete"
+		break
+	fi
+	FAILED=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get "job/${DEPLOY_NAME}" \
+		-o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+	if [[ "${FAILED}" == "True" ]]; then
+		STATE="failed"
+		break
 	fi
 	sleep 2
 done
 
-if [[ -z "${POD}" ]]; then
-	echo "ERROR: no pod found for deployment/${DEPLOY_NAME}" >&2
-	kubectl --context kind-hub get pods -A
-	exit 1
+POD=$(kubectl --context kind-hub -n "${DEPLOY_NS}" get pods \
+	-l "batch.kubernetes.io/job-name=${DEPLOY_NAME}" \
+	-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+LOGS=""
+if [[ -n "${POD}" ]]; then
+	LOGS=$(kubectl --context kind-hub -n "${DEPLOY_NS}" logs "${POD}" 2>&1 || true)
+	echo "${LOGS}"
 fi
 
-LOGS=$(kubectl --context kind-hub -n "${DEPLOY_NS}" logs "${POD}" 2>&1)
-echo "${LOGS}"
+case "${STATE}" in
+	complete) ;;
+	failed)
+		echo "ERROR: Job failed (plugin: ${PLUGIN_NAME})" >&2
+		kubectl --context kind-hub -n "${DEPLOY_NS}" describe "job/${DEPLOY_NAME}" >&2 || true
+		exit 1
+		;;
+	*)
+		echo "ERROR: Job timed out (plugin: ${PLUGIN_NAME})" >&2
+		kubectl --context kind-hub -n "${DEPLOY_NS}" describe "job/${DEPLOY_NAME}" >&2 || true
+		exit 1
+		;;
+esac
+
+if [[ -z "${POD}" ]]; then
+	echo "ERROR: no pod found for job/${DEPLOY_NAME}" >&2
+	kubectl --context kind-hub get pods -A >&2 || true
+	exit 1
+fi
 
 if ! echo "${LOGS}" | grep -q "\[client-go\] Listed"; then
 	echo "ERROR: logs missing [client-go] Listed" >&2

--- a/plugins/kubeconfig-secretreader/cmd/plugin/main.go
+++ b/plugins/kubeconfig-secretreader/cmd/plugin/main.go
@@ -211,9 +211,10 @@ func (p Provider) GetToken(
 	return status, nil
 }
 
-// inferNamespace determines the namespace to read Secrets from, preferring kubeconfig current-context
+// inferNamespace returns the namespace to read Secrets from, preferring the
+// kubeconfig current-context namespace and falling back to the namespace of
+// the Pod this process runs in.
 func inferNamespace() string {
-	// kubeconfig current-context namespace
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if path := os.Getenv("KUBECONFIG"); strings.TrimSpace(path) != "" {
 		rules.ExplicitPath = path
@@ -222,13 +223,6 @@ func inferNamespace() string {
 	if n, _, err := cc.Namespace(); err == nil && strings.TrimSpace(n) != "" {
 		return n
 	}
-	// in-cluster: try reading from service account namespace file
-	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-		if ns := strings.TrimSpace(string(data)); ns != "" {
-			return ns
-		}
-	}
-	// fallback to default namespace
 	return "default"
 }
 

--- a/plugins/secretreader/cmd/plugin/main.go
+++ b/plugins/secretreader/cmd/plugin/main.go
@@ -95,9 +95,10 @@ func (p Provider) GetToken(
 	return clientauthenticationv1.ExecCredentialStatus{Token: string(data)}, nil
 }
 
-// inferNamespace determines the namespace to read Secrets from, preferring kubeconfig current-context
+// inferNamespace returns the namespace to read Secrets from, preferring the
+// kubeconfig current-context namespace and falling back to the namespace of
+// the Pod this process runs in.
 func inferNamespace() string {
-	// kubeconfig current-context namespace
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if path := os.Getenv("KUBECONFIG"); strings.TrimSpace(path) != "" {
 		rules.ExplicitPath = path
@@ -106,7 +107,6 @@ func inferNamespace() string {
 	if n, _, err := cc.Namespace(); err == nil && strings.TrimSpace(n) != "" {
 		return n
 	}
-	// in-cluster kubeconfig is unavailable; library returns default namespace
 	return "default"
 }
 


### PR DESCRIPTION
## Summary

The existing e2e ran `controller-example` as a Deployment in the `default` namespace. If a plugin hardcoded `default` as its Secret namespace, that setup could not tell a correct plugin from a broken one. Unrelated plugin failures also only surfaced after the `kubectl rollout status` timeout. This PR moves the controller into a non-default namespace and runs it as a Job, so a regression in how the secret-reading plugins resolve their own Pod's namespace fails CI promptly.

In practice both plugins already resolve the namespace correctly via client-go's `DeferredLoadingClientConfig`, so the tightened coverage is purely a regression guard. The fallback that was written explicitly in `kubeconfig-secretreader` was duplicating [what client-go's in-cluster config already does](https://github.com/kubernetes/client-go/blob/v0.35.3/tools/clientcmd/client_config.go#L646-L661), so this PR drops it and reworks a misleading comment in both plugins.