### PR TITLE
fix(release): use existing Cloud Build builder image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: "E2_HIGHCPU_8"
 steps:
-  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251215-d7853fe2a6"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f"
     args:
       - make
       - release-staging


### PR DESCRIPTION
## Summary

Fix the Cloud Build step image used by the release image-pushing pipeline.

The `v0.1.1` image postsubmit was triggered, but it failed before building any project images because Cloud Build could not pull `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251215-d7853fe2a6`.

Failed Prow run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cluster-inventory-api-push-images/2055102363844218880

This updates `cloudbuild.yaml` to use `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f`, which is an existing `gcb-docker-gcloud` tag and matches current test-infra usage, for example in [`images/git/cloudbuild.yaml`](https://github.com/kubernetes/test-infra/blob/2a0e814342afcbad890d0bfbd567a7d7b8dede4e/images/git/cloudbuild.yaml#L2).

Related to #55.
