### PR TITLE
fix(release): honor target arch for plugin images

### DIFF
--- a/hack/Dockerfile.plugin
+++ b/hack/Dockerfile.plugin
@@ -18,10 +18,10 @@
 # When mounted at /plugin, the executable is /plugin/bin/<PLUGIN_NAME>-plugin.
 
 ARG PLUGIN_NAME
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG PLUGIN_NAME
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/cluster-inventory-api/issues/69

## Tests

After this change, local builds compile the binary for the requested platform:

```bash
OUT=$(mktemp -d)
docker buildx build \
  --platform linux/arm64 \
  -f hack/Dockerfile.plugin \
  --build-arg PLUGIN_NAME=secretreader \
  --output type=local,dest="$OUT" \
  .
file "$OUT/bin/secretreader-plugin"
```

The extracted build output is now an arm64 binary:
<img width="3456" height="952" alt="CleanShot 2026-06-09 at 11 06 25@2x" src="https://github.com/user-attachments/assets/88df8e2f-6d9e-4077-bbb9-fada49c4166a" />

```text
/var/folders/yd/0gwdn72s03ndv42vw_m52wgr0000gn/T/tmp.ce0KFDM8d4/bin/secretreader-plugin: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=3d25ce1e47a4c9a77df1178bf1971c062eed7285, stripped
```

I also verified the amd64 build output:

```bash
OUT=$(mktemp -d)
docker buildx build \
  --platform linux/amd64 \
  -f hack/Dockerfile.plugin \
  --build-arg PLUGIN_NAME=secretreader \
  --output type=local,dest="$OUT" \
  .
file "$OUT/bin/secretreader-plugin"
```

<img width="3456" height="942" alt="CleanShot 2026-06-09 at 11 07 17@2x" src="https://github.com/user-attachments/assets/b14ec87b-9fae-479c-a416-052d98f2a82d" />
