### PR TITLE
Validate ClusterManager names are non-empty

### DIFF
--- a/apis/v1alpha1/clusterprofile_types.go
+++ b/apis/v1alpha1/clusterprofile_types.go
@@ -47,6 +47,7 @@ type ClusterProfileSpec struct {
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ClusterManager is immutable"
 type ClusterManager struct {
 	// Name defines the name of the cluster manager
+	// +kubebuilder:validation:MinLength=1
 	// +required
 	Name string `json:"name"`
 }

--- a/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml
+++ b/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml
@@ -46,6 +46,7 @@ spec:
                 properties:
                   name:
                     description: Name defines the name of the cluster manager
+                    minLength: 1
                     type: string
                 required:
                 - name

--- a/test/integration/clusterprofile_test.go
+++ b/test/integration/clusterprofile_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -59,6 +60,25 @@ var _ = ginkgo.Describe("ClusterProfileAPI test", func() {
 			metav1.CreateOptions{},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject a ClusterProfile with an empty cluster manager name", func() {
+		clusterProfile := &cpv1alpha1.ClusterProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+			Spec: cpv1alpha1.ClusterProfileSpec{
+				DisplayName: clusterName,
+				ClusterManager: cpv1alpha1.ClusterManager{
+					Name: "",
+				},
+			},
+		}
+
+		_, err := clusterProfileClient.ApisV1alpha1().ClusterProfiles(testNamespace).Create(
+			context.TODO(),
+			clusterProfile,
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(apierrors.IsInvalid(err)).To(gomega.BeTrue())
 	})
 
 	ginkgo.It("Should update the ClusterProfile status", func() {


### PR DESCRIPTION
## What changed

- add `MinLength=1` validation to `spec.clusterManager.name`
- regenerate the ClusterProfile CRD with `minLength: 1`
- add an integration test that verifies an empty cluster manager name is rejected

## Why

The field was marked as required, but OpenAPI `required` only guarantees that the property exists. A ClusterProfile with `spec.clusterManager.name: ""` was therefore accepted even though the field identifies the manager responsible for the resource.

## User impact

The API server now rejects ClusterProfiles with an empty cluster manager name as invalid.
