### PR TITLE
test(integration): expand PlacementDecision validation coverage

### DIFF
--- a/test/integration/placementdecision_test.go
+++ b/test/integration/placementdecision_test.go
@@ -175,6 +175,42 @@ var _ = ginkgo.Describe("PlacementDecisionAPI test", func() {
 		gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue())
 	})
 
+	ginkgo.It("Should reject an update that grows a PlacementDecision beyond 100 decisions", func(ctx context.Context) {
+		decisions := make([]cpv1alpha2.ClusterDecision, 100)
+		for i := range decisions {
+			decisions[i] = cpv1alpha2.ClusterDecision{
+				ClusterProfileRef: cpv1alpha2.ClusterProfileReference{
+					Name: fmt.Sprintf("cluster-%d", i),
+				},
+			}
+		}
+
+		placementDecision, err := clusterProfileClient.ApisV1alpha2().PlacementDecisions(testNamespace).Create(
+			ctx,
+			&cpv1alpha2.PlacementDecision{
+				ObjectMeta: metav1.ObjectMeta{Name: decisionName},
+				Decisions:  decisions,
+			},
+			metav1.CreateOptions{},
+		)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		updated := placementDecision.DeepCopy()
+		updated.Decisions = append(updated.Decisions, cpv1alpha2.ClusterDecision{
+			ClusterProfileRef: cpv1alpha2.ClusterProfileReference{
+				Name: "cluster-last",
+			},
+		})
+
+		_, err = clusterProfileClient.ApisV1alpha2().PlacementDecisions(testNamespace).Update(
+			ctx,
+			updated,
+			metav1.UpdateOptions{},
+		)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue())
+	})
+
 	ginkgo.It("Should accept a PlacementDecision with a dotted cluster profile name", func(ctx context.Context) {
 		placementDecision := &cpv1alpha2.PlacementDecision{
 			ObjectMeta: metav1.ObjectMeta{Name: decisionName},


### PR DESCRIPTION
This pull request adds a new test case to the `PlacementDecisionAPI` integration tests to ensure that updates which increase a `PlacementDecision` resource beyond 100 decisions are correctly rejected. This helps enforce the intended validation logic for the maximum number of decisions.

**PlacementDecision validation:**

* Added a test (`Should reject an update that grows a PlacementDecision beyond 100 decisions`) to verify that the API returns an error when attempting to update a `PlacementDecision` to contain more than 100 decisions.

Resources:
Copilot https://github.com/Svarrogh1337/cluster-inventory-api/pull/2#pullrequestreview-4817189802